### PR TITLE
mawk

### DIFF
--- a/mysql2sqlite
+++ b/mysql2sqlite
@@ -122,7 +122,8 @@ inView != 0 { next }
   gsub( /\\_/, "\\" )
 
   # sqlite3 is limited to 16 significant digits of precision
-  while( match( $0, /0x[0-9a-fA-F]{17}/ ) ){
+  # we repeat the regex 17 times instead of using {17} for mawk compatibility
+  while( match( $0, /0x[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]/ ) ){
     hexIssue = 1
     sub( /0x[0-9a-fA-F]+/, substr( $0, RSTART, RLENGTH-1 ), $0 )
   }

--- a/unit_tests/test_one.sql.out
+++ b/unit_tests/test_one.sql.out
@@ -5,5 +5,5 @@ INSERT INTO `cache` (`cid`, `data`, `expire`, `created`, `headers`, `serialized`
 ('ctools_plugin_files:ctools:style_bases', 0x613a313a7b733a3, 0, 1440573529, '', 1),
 ('ctools_plugin_files:ctools:content_types', 0xa343a226e6f64652, 0, 1440573529, '', 1);
 INSERT INTO `cache` (`cid`, `data`, `expire`, `created`, `headers`, `serialized`) VALUES
-('theme_registry:my_theme', 0x613a3234353a7b733, 0, 1440572933, '', 1);
+('theme_registry:my_theme', 0x613a3234353a7b73, 0, 1440572933, '', 1);
 END TRANSACTION;


### PR DESCRIPTION
I had previously committed the expected output
`('theme_registry:my_theme', 0x613a3234353a7b733, 0, 1440572933, '', 1);`
however, this is incorrect. We should truncate to `0x613a3234353a7b73`

This fixes the bug / test case.